### PR TITLE
Add MarkExit Student Screen 

### DIFF
--- a/app/src/main/java/com/example/hostelite/MainActivity.kt
+++ b/app/src/main/java/com/example/hostelite/MainActivity.kt
@@ -16,6 +16,7 @@ import com.example.hostelite.landing_pages.AdminCreateAccount
 import com.example.hostelite.landing_pages.CreateAccountStudent
 import com.example.hostelite.landing_pages.Login
 import com.example.hostelite.student_screens.MarkEntry
+import com.example.hostelite.student_screens.MarkExit
 import com.example.hostelite.student_screens.StudentHome
 import com.example.hostelite.student_screens.StudentReportIssue
 import com.example.hostelite.ui.theme.HosteliteTheme
@@ -110,6 +111,9 @@ fun NavigationController(){
         }
         composable(route = "markentry"){
             MarkEntry(navController = navController)
+        }
+        composable(route = "markexit"){
+            MarkExit(navController = navController)
         }
     })
 }

--- a/app/src/main/java/com/example/hostelite/student_screens/MarkExit.kt
+++ b/app/src/main/java/com/example/hostelite/student_screens/MarkExit.kt
@@ -1,0 +1,93 @@
+package com.example.hostelite.student_screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.example.hostelite.R
+import com.example.hostelite.shared.widgets.AppBar
+
+@Composable
+fun MarkExit(navController: NavController) {
+    val reason = remember { mutableStateOf("") }
+    Scaffold(
+        topBar = { AppBar(navController = navController, text = "Mark Exit") }
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.bg),
+                contentDescription = null,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(20.dp)
+                    .fillMaxSize()
+            )
+            Image(
+                painter = painterResource(id = R.drawable.hostellite),
+                contentDescription = null,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 20.dp)
+                    .fillMaxWidth()
+            )
+            Column(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(horizontal = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                OutlinedTextField(
+                    value = reason.value,
+                    onValueChange = { reason.value = it },
+                    singleLine = true,
+                    placeholder = { Text(text = "Purpose of Exit") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(shape = RoundedCornerShape(corner = CornerSize(20.dp)))
+                        .background(color = Color(0xFFF7F7F7)),
+                    shape = RoundedCornerShape(corner = CornerSize(20.dp))
+                )
+                Spacer(modifier = Modifier.height(150.dp))
+                Row(
+                    modifier = Modifier
+                        .height(50.dp)
+                        .width(160.dp)
+                        .clip(shape = RoundedCornerShape(corner = CornerSize(size = 15.dp)))
+                        .background(color = Color(0xFFFE96FA))
+                        .clickable { /* Todo */ },
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "Mark Exit",
+                        style = TextStyle(
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.W400,
+                            color = Color(0xFF33004A)
+                        )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/hostelite/student_screens/StudentHome.kt
+++ b/app/src/main/java/com/example/hostelite/student_screens/StudentHome.kt
@@ -259,7 +259,8 @@ fun StudentHome(navController: NavController){
                                     modifier = Modifier
                                         .clip(shape = RoundedCornerShape(corner = CornerSize(20.dp)))
                                         .background(Color(0xFF51E71D))
-                                        .weight(1f),
+                                        .weight(1f)
+                                        .clickable { navController.navigate(route = "markexit")},
                                     verticalAlignment = Alignment.CenterVertically
                                 ){
                                     Image(


### PR DESCRIPTION
- **Info about the issue** : This PR will add the Exit Screen into the application.
- **Name** : Ritwik Singh
- **GitHub ID** : RitwikSingh28
- **Identification**: Hacktoberfest Contributor

Resolves #7 

**Approach**
- I have created a TextField that takes in a String denoting the reason for exit of the student.
- A submit button has been added near the end for submission of Exit Data.

**Changes**
The only change is the removal of **Room No**, **Roll No**,  and **Hostel Name** textfields from the original design, as I found it redundant to ask the user to enter it frequently, when it has already been provided during the Account Setup phase.

**Screenshot**
![exit_ss](https://user-images.githubusercontent.com/106133014/194086526-8959386b-3866-4846-85e1-016be576ddfb.jpeg)
